### PR TITLE
Issue #13

### DIFF
--- a/backend/Types/SocketEvents.ts
+++ b/backend/Types/SocketEvents.ts
@@ -3,7 +3,8 @@ export enum GameEvents {
     DISCONNECT = 'disconnect',
     GAME_UPDATE = 'game_update',
     GAME_DELETE = 'game_delete',
-    LEAVE_GAME = 'leave_game'
+    LEAVE_GAME = 'leave_game',
+    CREATE_STORY = 'create_story'
 }
 
 export enum UserEvents {

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -175,6 +175,12 @@ export class App {
                 this.logger.socket(`${UserEvents.ROLE_CHANGE}`);
                 this.io.emit('client_user_role_change', m)
             })
+
+            socket.on(GameEvents.CREATE_STORY, () => {
+                this.logger.socket(`${GameEvents.CREATE_STORY}`);
+
+                this.io.emit('client_story_was_added', {gameId: socketData.gameId});
+            })
         });
     }
 

--- a/client/src/Pages/Games/Game.vue
+++ b/client/src/Pages/Games/Game.vue
@@ -380,6 +380,16 @@ export default {
                 that.updateGame();
               })
             })
+
+            this.$socketStore.socket.on('client_story_was_added', function(data) {
+              console.log(data, that.$route.params.id);
+              if (data.gameId !== that.$route.params.id) {
+                return;
+              }
+
+              that.updateGame();
+              that.handleAutoSwitchStory();
+            })
           });
     },
 

--- a/client/src/components/Stories/CreateStory.vue
+++ b/client/src/components/Stories/CreateStory.vue
@@ -176,7 +176,7 @@ export default {
 
         this.changeStory();
 
-        this.$socketStore.emitEvent(GameEvents.GAME_UPDATE, {gameId: this.$gameStore.game.gameId});
+        this.$socketStore.emitEvent(GameEvents.CREATE_STORY, {gameId: this.$gameStore.game.gameId});
         this.submitting = false;
       });
     },

--- a/client/src/components/Stories/GameStories.vue
+++ b/client/src/components/Stories/GameStories.vue
@@ -152,7 +152,6 @@ export default {
   watch: {
     forceUpdate(newVal, oldVal) {
       if (oldVal && newVal === false) {
-        console.log("Hm");
         this.stories = this.$gameStore.game.stories;
       }
     }

--- a/client/src/constants/contants.ts
+++ b/client/src/constants/contants.ts
@@ -3,7 +3,8 @@ export enum GameEvents {
     DISCONNECT = 'disconnect',
     GAME_UPDATE = 'game_update',
     GAME_DELETE = 'game_delete',
-    LEAVE_GAME = 'leave_game'
+    LEAVE_GAME = 'leave_game',
+    CREATE_STORY = 'create_story'
 }
 
 export enum UserEvents {


### PR DESCRIPTION
Confirmed that when the "Automatically switch to the next story when estimate has been set?" option is selected and the game has gone progressed through all the stories and an editor or master admin adds a new story, it will automatically switch to that story.

Confirmed that functionality still works as expected with the current story logic when this option is not selected.

Closes #13  